### PR TITLE
Run replacement across entire workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "regreplace"
     ],
     "activationEvents": [
-        "onCommand:extension.chooseRule"
+        "onCommand:extension.chooseRule",
+        "onCommand:extension.chooseRuleGlobal"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -29,6 +30,11 @@
             {
                 "command": "extension.chooseRule",
                 "title": "Run Rule...",
+                "category": "Replace Rules"
+            },
+            {
+                "command": "extension.chooseRuleGlobal",
+                "title": "Run Rule Globally...",
                 "category": "Replace Rules"
             }
         ],
@@ -93,7 +99,10 @@
                                 "description": "(Optional) A set of workspace language ids that the rule is restricted to. For example, a rule with 'languages' set to 'typescript' will only appear in the Run Rule... menu if TypeScript is the active language on the active document."
                             }
                         },
-                        "required": [ "name", "find" ],
+                        "required": [
+                            "name",
+                            "find"
+                        ],
                         "additionalProperties": false
                     }
                 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,9 +4,16 @@ import ReplaceRulesEditProvider from './editProvider';
 
 export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerTextEditorCommand('extension.chooseRule', ruleReplace));
+    context.subscriptions.push(vscode.commands.registerTextEditorCommand('extension.chooseRuleGlobal', ruleReplaceGlobal));
+
 }
 
 function ruleReplace(textEditor: vscode.TextEditor) {
-    new ReplaceRulesEditProvider(textEditor).chooseRule();
+    new ReplaceRulesEditProvider(textEditor).chooseRule(false);
+    return;
+}
+
+function ruleReplaceGlobal(textEditor: vscode.TextEditor) {
+    new ReplaceRulesEditProvider(textEditor).chooseRule(true);
     return;
 }


### PR DESCRIPTION
I was looking for an extension to globally replace regex across a workspace. Yours seemed to be the closest, but not quite what I was looking for.

I have no experience with VS Code Extensions, but I tinkered with it until it did a workspace level replacement. Not sure if I did it the "right" way at all, but thought the code might be helpful if you thought the feature would be useful to other people.

I hardcoded if for `ts|tsx` files because that's what I was working with. Would be nice to have a file match regex as an option on a rule. I don't know how to do that.