### PR TITLE
Add an option to perform a literal (non-regex) search

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Press <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>R</kbd> and select the rule you'd like
 - `replace` - (Optional) A sequence of regular expressions used as replacements. Can be a single string or an array of strings. If this is an empty string or unspecified, each `find` will be deleted rather than replaced.
 - `flags` - (Optional) A set of regex flags to apply to the rule. If only one set of flags is specified, it will be applied to all `finds` in the rule. The default flags are gm (global, multiline).
 - `languages` - (Optional) An array of workspace language ids that the rule is restricted to. For example, a rule with `languages` set to 'typescript' will only appear in the **Run Rule...** menu if TypeScript is the active language on the active document.
+- `literal` - (Optional) Perform a non-regex, literal search and replace.
 
 ### Rulesets
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
                                 "languages": {
                                     "type": "array",
                                     "description": "(Optional) A set of workspace language ids that the rule is restricted to. For example, a rule with 'languages' set to 'typescript' will only appear in the Run Rule... menu if TypeScript is the active language on the active document."
+                                },
+                                "literal": {
+                                    "type": "boolean",
+                                    "description": "(Optional) Perform a non-regex, literal search and replace."
                                 }
                             },
                             "required": [

--- a/src/editProvider.ts
+++ b/src/editProvider.ts
@@ -145,7 +145,7 @@ class Replacement {
         if (flags) {
             flags = (flags.search('g') === -1) ? flags + 'g' : flags;
         }
-        this.find = new RegExp(find, flags || Replacement.defaultFlags);
+        this.find = literal ? find : (new RegExp(find, flags || Replacement.defaultFlags));
         this.replace = replace || '';
     }
 }
@@ -157,7 +157,7 @@ class ReplaceRule {
         let ruleSteps: Replacement[] = [];
         let find = objToArray(rule.find);
         for (let i = 0; i < find.length; i++) {
-            ruleSteps.push(new Replacement(find[i], objToArray(rule.replace)[i], objToArray(rule.flags)[i]));
+            ruleSteps.push(new Replacement(find[i], objToArray(rule.replace)[i], objToArray(rule.flags)[i],objToArray(rule.literal)[i]));
         }
         this.steps = ruleSteps;
     }
@@ -165,7 +165,7 @@ class ReplaceRule {
     public appendRule(newRule: any) {
         let find = objToArray(newRule.find);
         for (let i = 0; i < find.length; i++) {
-            this.steps.push(new Replacement(find[i], objToArray(newRule.replace)[i], objToArray(newRule.flags)[i]));
+            this.steps.push(new Replacement(find[i], objToArray(newRule.replace)[i], objToArray(newRule.flags)[i], objToArray(rule.literal)[i]));
         }
     }
 }


### PR DESCRIPTION
The "literal" option (false by default) allows you to perform a non-regex search. I've been using it all the time in Sublime Text's [RegReplace](https://facelessuser.github.io/RegReplace/usage/#__code_1), so this addition should make the rule syntax a bit more compatible with that plugin.